### PR TITLE
Add new parameter -extra-values to generate functions returning slices of strings of the enumerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It started as a fork of [Rob Pike’s Stringer tool](https://godoc.org/golang.or
 Enumer can be installed as any other go command:
 
 ```
-go install github.com/loggerhead/enumer
+go install github.com/stevendpclark/enumer
 ```
 After that, the `enumer` executable will be in "$GOPATH/bin" folder and you can use it with `go generate`
 
@@ -34,6 +34,9 @@ convert the map keys to json (strings). If not, the numeric values will be used 
 the enum conform to the `gopkg.in/yaml.v2.Marshaler` and `gopkg.in/yaml.v2.Unmarshaler` interfaces.
 * When the flag `sql` is provided, the methods for implementing the Scanner and Valuer interfaces will be also generated.
 Useful when storing the enum in a database.
+* When the flag `extra-values` is provided, two additional methods will be generated, `<Type>ValuesAsStr()` which returns
+a slice of strings that represent all the enumerations and `<Type>sStrValuesAsAny` which returns the same slice as `<Type>ValuesAsStr()` 
+but is returned as a slice of any values.
 
 For example, if we have an enum type called `Pill`,
 ```go
@@ -134,8 +137,8 @@ name := MyTypeValue.String() // name => "my_type_value"
 The usage of Enumer is the same as Stringer, so you can refer to the [Stringer docs](https://godoc.org/golang.org/x/tools/cmd/stringer)
 for more information.
 
-There are four boolean flags: `json`, `text`, `yaml` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
-
+There are five boolean flags: `extra-values`, `json`, `text`, `yaml` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
+Note that `extra-values` boolean flag that is new to this package, which adds extra functions that return the enumeration as different value types.
 
 For enum string representation transformation the `transform` and `trimprefix` flags
 were added (i.e. `enumer -type=MyType -json -transform=snake`).

--- a/endtoend_test.go
+++ b/endtoend_test.go
@@ -4,6 +4,7 @@
 
 // go command is not available on android
 
+//go:build !android
 // +build !android
 
 package main
@@ -12,7 +13,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,14 +26,11 @@ import (
 // binary panics if the String method for X is not correct, including for error cases.
 
 func TestEndToEnd(t *testing.T) {
-	dir, err := ioutil.TempDir("", "stringer")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	// Create stringer in temporary directory.
 	stringer := filepath.Join(dir, "stringer.exe")
-	err = run("go", "build", "-o", stringer)
+	err := run("go", "build", "-o", stringer)
 	if err != nil {
 		t.Fatalf("building stringer: %s", err)
 	}

--- a/enumer.go
+++ b/enumer.go
@@ -3,6 +3,7 @@ package main
 import "fmt"
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringNameToValueMethod = `// %[1]sString retrieves an enum value from the enum constants string name.
 // Throws an error if the param is not part of the enum.
@@ -15,6 +16,7 @@ func %[1]sString(s string) (%[1]s, error) {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringValuesMethod = `// %[1]sValues returns all values of the enum
 func %[1]sValues() []%[1]s {
@@ -22,7 +24,28 @@ func %[1]sValues() []%[1]s {
 }
 `
 
+const valuesAsStringMethod = `// %[1]sValuesAsStr returns all values of the enum as strings
+func %[1]sValuesAsStr() []string {
+    var res []string
+	for _, v := range _%[1]sValues {
+		res = append(res, v.String())
+    }
+    return res
+}
+`
+
+const valuesAsAnyMethod = `// %[1]sStrValuesAsAny returns all values of the enum as slice of any containing strings
+func %[1]sStrValuesAsAny() []any {
+    var res []any
+	for _, v := range _%[1]sValues {
+		res = append(res, v.String())
+    }
+    return res
+}
+`
+
 // Arguments to format are:
+//
 //	[1]: type name
 const stringBelongsMethodLoop = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -36,6 +59,7 @@ func (i %[1]s) IsA%[1]s() bool {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringBelongsMethodSet = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -87,6 +111,7 @@ func (g *Generator) buildBasicExtras(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const jsonMethods = `
 // MarshalJSON implements the json.Marshaler interface for %[1]s
@@ -112,6 +137,7 @@ func (g *Generator) buildJSONMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const textMethods = `
 // MarshalText implements the encoding.TextMarshaler interface for %[1]s
@@ -132,6 +158,7 @@ func (g *Generator) buildTextMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const yamlMethods = `
 // MarshalYAML implements a YAML Marshaler for %[1]s

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stevendpclark/enumer
 go 1.23.0
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/pascaldekloe/name v1.0.1
 	golang.org/x/tools v0.29.0
 )

--- a/golden_test.go
+++ b/golden_test.go
@@ -10,11 +10,12 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // Golden represents a test case.
@@ -58,6 +59,10 @@ var goldenPrefix = []Golden{
 
 var goldenWithLineComments = []Golden{
 	{"primer with line Comments", primeWithLineCommentIn, primeWithLineCommentOut},
+}
+
+var goldenExtraValues = []Golden{
+	{"extra value functions", dayIn, dayOutExtraValues},
 }
 
 // Each example starts with "type XXX [u]int", with a single space separating them.
@@ -121,6 +126,73 @@ func (i Day) IsADay() bool {
 		}
 	}
 	return false
+}
+`
+
+const dayOutExtraValues = `
+const _DayName = "MondayTuesdayWednesdayThursdayFridaySaturdaySunday"
+
+var _DayIndex = [...]uint8{0, 6, 13, 22, 30, 36, 44, 50}
+
+func (i Day) String() string {
+	if i < 0 || i >= Day(len(_DayIndex)-1) {
+		return fmt.Sprintf("Day(%d)", i)
+	}
+	return _DayName[_DayIndex[i]:_DayIndex[i+1]]
+}
+
+var _DayValues = []Day{0, 1, 2, 3, 4, 5, 6}
+
+var _DayNameToValueMap = map[string]Day{
+	_DayName[0:6]:   0,
+	_DayName[6:13]:  1,
+	_DayName[13:22]: 2,
+	_DayName[22:30]: 3,
+	_DayName[30:36]: 4,
+	_DayName[36:44]: 5,
+	_DayName[44:50]: 6,
+}
+
+// DayString retrieves an enum value from the enum constants string name.
+// Throws an error if the param is not part of the enum.
+func DayString(s string) (Day, error) {
+	if val, ok := _DayNameToValueMap[s]; ok {
+		return val, nil
+	}
+	return 0, fmt.Errorf("%s does not belong to Day values", s)
+}
+
+// DayValues returns all values of the enum
+func DayValues() []Day {
+	return _DayValues
+}
+
+// IsADay returns "true" if the value is listed in the enum definition. "false" otherwise
+func (i Day) IsADay() bool {
+	for _, v := range _DayValues {
+		if i == v {
+			return true
+		}
+	}
+	return false
+}
+
+// DayValuesAsStr returns all values of the enum as strings
+func DayValuesAsStr() []string {
+	var res []string
+	for _, v := range _DayValues {
+		res = append(res, v.String())
+	}
+	return res
+}
+
+// DayStrValuesAsAny returns all values of the enum as slice of any containing strings
+func DayStrValuesAsAny() []any {
+	var res []any
+	for _, v := range _DayValues {
+		res = append(res, v.String())
+	}
+	return res
 }
 `
 
@@ -1115,58 +1187,54 @@ func (i Prime) IsAPrime() bool {
 
 func TestGolden(t *testing.T) {
 	for _, test := range golden {
-		runGoldenTest(t, test, false, false, false, false, "")
+		runGoldenTest(t, test, false, false, false, false, false, "")
 	}
 	for _, test := range goldenJSON {
-		runGoldenTest(t, test, true, false, false, false, "")
+		runGoldenTest(t, test, true, false, false, false, false, "")
 	}
 	for _, test := range goldenText {
-		runGoldenTest(t, test, false, false, false, true, "")
+		runGoldenTest(t, test, false, false, false, true, false, "")
 	}
 	for _, test := range goldenYAML {
-		runGoldenTest(t, test, false, true, false, false, "")
+		runGoldenTest(t, test, false, true, false, false, false, "")
 	}
 	for _, test := range goldenSQL {
-		runGoldenTest(t, test, false, false, true, false, "")
+		runGoldenTest(t, test, false, false, true, false, false, "")
 	}
 	for _, test := range goldenJSONAndSQL {
-		runGoldenTest(t, test, true, false, true, false, "")
+		runGoldenTest(t, test, true, false, true, false, false, "")
 	}
 	for _, test := range goldenPrefix {
-		runGoldenTest(t, test, false, false, false, false, "Day")
+		runGoldenTest(t, test, false, false, false, false, false, "Day")
+	}
+	for _, test := range goldenExtraValues {
+		runGoldenTest(t, test, false, false, false, false, true, "")
 	}
 }
 
-func runGoldenTest(t *testing.T, test Golden, generateJSON, generateYAML, generateSQL, generateText bool, prefix string) {
-	var g Generator
-	input := "package test\n" + test.input
-	file := test.name + ".go"
+func runGoldenTest(t *testing.T, test Golden, generateJSON, generateYAML, generateSQL, generateText, generateExtraValues bool, prefix string) {
+	t.Run(test.name, func(t *testing.T) {
+		var g Generator
+		input := "package test\n" + test.input
+		file := test.name + ".go"
 
-	dir, err := ioutil.TempDir("", "stringer")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		err = os.RemoveAll(dir)
+		dir := t.TempDir()
+
+		absFile := filepath.Join(dir, file)
+		err := os.WriteFile(absFile, []byte(input), 0644)
 		if err != nil {
 			t.Error(err)
 		}
-	}()
-
-	absFile := filepath.Join(dir, file)
-	err = ioutil.WriteFile(absFile, []byte(input), 0644)
-	if err != nil {
-		t.Error(err)
-	}
-	g.parsePackage([]string{absFile})
-	// Extract the name and type of the constant from the first line.
-	tokens := strings.SplitN(test.input, " ", 3)
-	if len(tokens) != 3 {
-		t.Fatalf("%s: need type declaration on first line", test.name)
-	}
-	g.generate(tokens[1], generateJSON, generateYAML, generateSQL, generateText, "noop", prefix, false)
-	got := string(g.format())
-	if got != test.output {
-		t.Errorf("%s: got\n====\n%s====\nexpected\n====%s", test.name, got, test.output)
-	}
+		g.parsePackage([]string{absFile})
+		// Extract the name and type of the constant from the first line.
+		tokens := strings.SplitN(test.input, " ", 3)
+		if len(tokens) != 3 {
+			t.Fatalf("%s: need type declaration on first line", test.name)
+		}
+		g.generate(tokens[1], generateJSON, generateYAML, generateSQL, generateText, generateExtraValues, "noop", prefix, false)
+		got := string(g.format())
+		if diffs := cmp.Diff(test.output, got); diffs != "" {
+			t.Errorf("%s: diffs:%v\n\n got\n====\n%s====\nexpected\n====%s", test.name, diffs, got, test.output)
+		}
+	})
 }

--- a/sql.go
+++ b/sql.go
@@ -1,6 +1,7 @@
 package main
 
 // Arguments to format are:
+//
 //	[1]: type name
 const valueMethod = `func (i %[1]s) Value() (driver.Value, error) {
 	return i.String(), nil

--- a/stringer.go
+++ b/stringer.go
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
-//Enumer is a tool to generate Go code that adds useful methods to Go enums (constants with a specific type).
-//It started as a fork of Rob Pike’s Stringer tool
+// Enumer is a tool to generate Go code that adds useful methods to Go enums (constants with a specific type).
+// It started as a fork of Rob Pike’s Stringer tool
 //
-//Please visit http://github.com/loggerhead/enumer for a comprehensive documentation
+// Please visit http://github.com/loggerhead/enumer for a comprehensive documentation
 package main
 
 import (
@@ -20,13 +21,14 @@ import (
 	"go/importer"
 	"go/token"
 	"go/types"
-	"golang.org/x/tools/go/packages"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 
 	"github.com/pascaldekloe/name"
 )
@@ -48,8 +50,9 @@ var (
 	json            = flag.Bool("json", false, "if true, json marshaling methods will be generated. Default: false")
 	yaml            = flag.Bool("yaml", false, "if true, yaml marshaling methods will be generated. Default: false")
 	text            = flag.Bool("text", false, "if true, text marshaling methods will be generated. Default: false")
+	extraValues     = flag.Bool("extra-values", false, "if true, ValuesAsStr and ValuesAsAny methods will be generated. Default: false")
 	output          = flag.String("output", "", "output file name; default srcdir/<type>_enumer.go")
-	transformMethod = flag.String("transform", "noop", "enum item name transformation method. Default: noop")
+	transformMethod = flag.String("transform", "noop", "enum item name transformation method. values allowed are snake,kebab,lowercamel. Default: noop")
 	trimPrefix      = flag.String("trimprefix", "", "transform each item name by removing a prefix. Default: \"\"")
 	lineComment     = flag.Bool("linecomment", false, "use line comment text as printed text when present")
 )
@@ -66,7 +69,7 @@ func Usage() {
 	fmt.Fprintf(os.Stderr, "\tenumer [flags] -type T [directory]\n")
 	fmt.Fprintf(os.Stderr, "\tenumer [flags] -type T files... # Must be a single package\n")
 	fmt.Fprintf(os.Stderr, "For more information, see:\n")
-	fmt.Fprintf(os.Stderr, "\thttps://github.com/loggerhead/enumer\n")
+	fmt.Fprintf(os.Stderr, "\thttps://github.com/stevendpclark/enumer\n")
 	fmt.Fprintf(os.Stderr, "Flags:\n")
 	flag.PrintDefaults()
 }
@@ -121,7 +124,7 @@ func main() {
 
 	// Run generate for each type.
 	for _, typeName := range types {
-		g.generate(typeName, *json, *yaml, *sql, *text, *transformMethod, *trimPrefix, *lineComment)
+		g.generate(typeName, *json, *yaml, *sql, *text, *extraValues, *transformMethod, *trimPrefix, *lineComment)
 	}
 
 	// Format the output.
@@ -346,7 +349,7 @@ func (g *Generator) replaceValuesWithLineComment(values []Value) {
 }
 
 // generate produces the String method for the named type.
-func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeSQL, includeText bool, transformMethod string, trimPrefix string, lineComment bool) {
+func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeSQL, includeText, includeExtraValues bool, transformMethod, trimPrefix string, lineComment bool) {
 	values := make([]Value, 0, 100)
 	for _, file := range g.pkg.files {
 		// Set the state for this run of the walker.
@@ -394,6 +397,9 @@ func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeS
 	}
 
 	g.buildBasicExtras(runs, typeName, runsThreshold)
+	if includeExtraValues {
+		g.buildExtraValueMethods(typeName)
+	}
 	if includeJSON {
 		g.buildJSONMethods(runs, typeName, runsThreshold)
 	}
@@ -663,6 +669,7 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 //	[2]: size of index element (8 for uint8 etc.)
 //	[3]: less than zero check (for signed types)
@@ -731,6 +738,11 @@ func (g *Generator) buildMap(runs [][]Value, typeName string) {
 	}
 	g.Printf("}\n\n")
 	g.Printf(stringMap, typeName)
+}
+
+func (g *Generator) buildExtraValueMethods(typeName string) {
+	g.Printf(valuesAsStringMethod, typeName)
+	g.Printf(valuesAsAnyMethod, typeName)
 }
 
 // Argument to format is the type name.


### PR DESCRIPTION
Add a new boolean parameter to enumer called -extra-values that will add two new functions to generate. These are mainly to help with Vault use-cases of using these values as arguments for parameters. 

The two additional methods will be generated, `<Type>ValuesAsStr()` which returns a slice of strings that represent all the enumerations and `<Type>sStrValuesAsAny` which returns the same slice as `<Type>ValuesAsStr()`  but is returned as a slice of any values.

