### PR TITLE
Chore: Update GH actions and use Go 1.26 release versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,12 +20,12 @@ jobs:
         go-version:
           - '1.24'
           - '1.25'
-          - '1.26.0-rc.2'
+          - '1.26'
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
Update GH actions 

- actions/checkout from 6.0.1 to 6.0.2
- actions/setup-go from 6.2.0 to 6.4.0

Use release versions of Go 1.26 within GH pipeline instead of 1.26.0-rc2